### PR TITLE
New PLY loading backend with support for custom attributes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ list(APPEND CMAKE_MODULE_PATH ${EXTERNAL_DEP_DIR}/numpyeigen/cmake)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 include(numpyeigen) # This will define Eigen3::Eigen if we enabled NPE_WITH_EIGEN
 
+download_dep(tinyply
+        GIT_REPOSITORY https://github.com/fwilliams/tinyply.git
+        GIT_TAG point_cloud_utils
+)
+
 # Build manifold as a static lib
 download_dep(manifold
   GIT_REPOSITORY https://github.com/hjwdzh/Manifold.git
@@ -35,7 +40,7 @@ set(
     ${MANIFOLD_SRC_DIR}/main.cpp
     ${MANIFOLD_SRC_DIR}/Model_OBJ.cpp
     ${MANIFOLD_SRC_DIR}/Model_OBJ.h
-    ${MANIFOLD_SRC_DIR}/Octree.h)
+    ${MANIFOLD_SRC_DIR}/Octree.h src/common/ply_loader.h)
 add_library(manifold STATIC ${manifold_SRC})
 set_target_properties(manifold PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(manifold PUBLIC ${MANIFOLD_SRC_DIR})
@@ -149,6 +154,8 @@ target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/morto
 target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/geogram_utils.cpp)
 target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/embree_intersector.cpp)
 target_sources(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/vcglib/wrap/ply/plylib.cpp)
+target_sources(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/tinyply/source/tinyply.cpp)
+target_include_directories(_pcu_internal PRIVATE ${EXTERNAL_DEP_DIR}/tinyply/source)
 target_include_directories(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/vcglib)
 target_include_directories(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_include_directories(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/nanoflann)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(
     ${MANIFOLD_SRC_DIR}/main.cpp
     ${MANIFOLD_SRC_DIR}/Model_OBJ.cpp
     ${MANIFOLD_SRC_DIR}/Model_OBJ.h
-    ${MANIFOLD_SRC_DIR}/Octree.h src/common/ply_loader.h)
+    ${MANIFOLD_SRC_DIR}/Octree.h)
 add_library(manifold STATIC ${manifold_SRC})
 set_target_properties(manifold PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(manifold PUBLIC ${MANIFOLD_SRC_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/morto
 target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/geogram_utils.cpp)
 target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/embree_intersector.cpp)
 target_sources(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/vcglib/wrap/ply/plylib.cpp)
-target_sources(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/tinyply/source/tinyply.cpp)
+# target_sources(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/tinyply/source/tinyply.cpp)
 target_include_directories(_pcu_internal PRIVATE ${EXTERNAL_DEP_DIR}/tinyply/source)
 target_include_directories(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/vcglib)
 target_include_directories(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/external/vcglib/wrap/io_trimesh/import.h
+++ b/external/vcglib/wrap/io_trimesh/import.h
@@ -68,8 +68,9 @@ Initial Update
 #include <wrap/io_trimesh/import_ply.h>
 #include <wrap/io_trimesh/import_stl.h>
 #include <wrap/io_trimesh/import_off.h>
+#ifndef __APPLE__
 #include <wrap/io_trimesh/import_vmi.h>
-
+#endif
 #include <locale>
 
 namespace vcg {
@@ -85,7 +86,12 @@ template <class OpenMeshType>
 class Importer
 {
 private:
-  enum KnownTypes { KT_UNKNOWN, KT_PLY, KT_STL, KT_OFF, KT_OBJ, KT_VMI };
+  enum KnownTypes { KT_UNKNOWN, KT_PLY, KT_STL, KT_OFF, KT_OBJ,
+
+#ifndef __APPLE__
+          KT_VMI
+#endif
+  };
 static int &LastType()
 {
   static int lastType= KT_UNKNOWN;
@@ -135,11 +141,13 @@ static int Open(OpenMeshType &m, const char *filename, int &loadmask, CallBackPo
 		err = ImporterOBJ<OpenMeshType>::Open(m, filename, loadmask, cb);
 		LastType()=KT_OBJ;
 	}
+#ifndef __APPLE__
     else if(FileExtension(filename,"vmi"))
     {
         err = ImporterVMI<OpenMeshType>::Open(m, filename, loadmask, cb);
         LastType()=KT_VMI;
     }
+#endif
   else {
 		err=1;
 		LastType()=KT_UNKNOWN;
@@ -169,7 +177,9 @@ static const char *ErrorMsg(int error)
     case KT_STL : return ImporterSTL<OpenMeshType>::ErrorMsg(error); break;
     case KT_OFF : return ImporterOFF<OpenMeshType>::ErrorMsg(error); break;
     case KT_OBJ : return ImporterOBJ<OpenMeshType>::ErrorMsg(error); break;
+#ifndef __APPLE__
     case KT_VMI : return ImporterVMI<OpenMeshType>::ErrorMsg(error); break;
+#endif
   }
   return "Unknown type";
 }

--- a/external/vcglib/wrap/io_trimesh/import.h
+++ b/external/vcglib/wrap/io_trimesh/import.h
@@ -68,9 +68,8 @@ Initial Update
 #include <wrap/io_trimesh/import_ply.h>
 #include <wrap/io_trimesh/import_stl.h>
 #include <wrap/io_trimesh/import_off.h>
-#ifndef __APPLE__
 #include <wrap/io_trimesh/import_vmi.h>
-#endif
+
 #include <locale>
 
 namespace vcg {
@@ -86,12 +85,7 @@ template <class OpenMeshType>
 class Importer
 {
 private:
-  enum KnownTypes { KT_UNKNOWN, KT_PLY, KT_STL, KT_OFF, KT_OBJ,
-
-#ifndef __APPLE__
-          KT_VMI
-#endif
-  };
+  enum KnownTypes { KT_UNKNOWN, KT_PLY, KT_STL, KT_OFF, KT_OBJ, KT_VMI };
 static int &LastType()
 {
   static int lastType= KT_UNKNOWN;
@@ -141,13 +135,11 @@ static int Open(OpenMeshType &m, const char *filename, int &loadmask, CallBackPo
 		err = ImporterOBJ<OpenMeshType>::Open(m, filename, loadmask, cb);
 		LastType()=KT_OBJ;
 	}
-#ifndef __APPLE__
     else if(FileExtension(filename,"vmi"))
     {
         err = ImporterVMI<OpenMeshType>::Open(m, filename, loadmask, cb);
         LastType()=KT_VMI;
     }
-#endif
   else {
 		err=1;
 		LastType()=KT_UNKNOWN;
@@ -177,9 +169,7 @@ static const char *ErrorMsg(int error)
     case KT_STL : return ImporterSTL<OpenMeshType>::ErrorMsg(error); break;
     case KT_OFF : return ImporterOFF<OpenMeshType>::ErrorMsg(error); break;
     case KT_OBJ : return ImporterOBJ<OpenMeshType>::ErrorMsg(error); break;
-#ifndef __APPLE__
     case KT_VMI : return ImporterVMI<OpenMeshType>::ErrorMsg(error); break;
-#endif
   }
   return "Unknown type";
 }

--- a/point_cloud_utils/_mesh_io.py
+++ b/point_cloud_utils/_mesh_io.py
@@ -96,7 +96,13 @@ class TriangleMesh:
             if key == "alpha":
                 self.colors[:, -1] = np.squeeze(clr_array)
             elif key == "colors":
-                self.colors[:, :-1] = clr_array
+                if clr_array.shape[1] == 3:
+                    self.colors[:, :-1] = clr_array
+                elif clr_array.shape[1] == 4:
+                    self.colors = clr_array
+                else:
+                    raise ValueError("Invalid shape for vertex colors must be "
+                                     "(n, 3) or (n, 4) but got " + str(clr_array.shape))
             else:
                 assert False
 
@@ -170,7 +176,13 @@ class TriangleMesh:
             if key == "alpha":
                 self.colors[:, -1] = np.squeeze(clr_array)
             elif key == "colors":
-                self.colors[:, :-1] = clr_array
+                if clr_array.shape[1] == 3:
+                    self.colors[:, :-1] = clr_array
+                elif clr_array.shape[1] == 4:
+                    self.colors = clr_array
+                else:
+                    raise ValueError("Invalid shape for face colors must be "
+                                     "(n, 3) or (n, 4) but got " + str(clr_array.shape))
             else:
                 assert False
 

--- a/point_cloud_utils/_mesh_io.py
+++ b/point_cloud_utils/_mesh_io.py
@@ -272,8 +272,8 @@ class TriangleMesh:
                            np.ascontiguousarray(self.face_data.wedge_normals.astype(dtype)),
                            np.ascontiguousarray(self.face_data.wedge_texcoords.astype(dtype)),
                            np.ascontiguousarray(self.face_data.wedge_tex_ids.astype(np.int32)),
-                           {k: np.ascontiguousarray(v) if isinstance(v, np.array) else v for (k, v) in self.vertex_data.custom_attributes.items()},
-                           {k: np.ascontiguousarray(v) if isinstance(v, np.array) else v for (k, v) in self.face_data.custom_attributes.items()},
+                           {k: np.ascontiguousarray(v) if isinstance(v, np.ndarray) else v for (k, v) in self.vertex_data.custom_attributes.items()},
+                           {k: np.ascontiguousarray(v) if isinstance(v, np.ndarray) else v for (k, v) in self.face_data.custom_attributes.items()},
                            self.textures, self.normal_maps, dtype, np.int32)
         self.vertex_data._set_empty_to_none()
         self.face_data._set_empty_to_none()

--- a/point_cloud_utils/_mesh_io.py
+++ b/point_cloud_utils/_mesh_io.py
@@ -272,6 +272,8 @@ class TriangleMesh:
                            np.ascontiguousarray(self.face_data.wedge_normals.astype(dtype)),
                            np.ascontiguousarray(self.face_data.wedge_texcoords.astype(dtype)),
                            np.ascontiguousarray(self.face_data.wedge_tex_ids.astype(np.int32)),
+                           {k: np.ascontiguousarray(v) if isinstance(v, np.array) else v for (k, v) in self.vertex_data.custom_attributes.items()},
+                           {k: np.ascontiguousarray(v) if isinstance(v, np.array) else v for (k, v) in self.face_data.custom_attributes.items()},
                            self.textures, self.normal_maps, dtype, np.int32)
         self.vertex_data._set_empty_to_none()
         self.face_data._set_empty_to_none()

--- a/point_cloud_utils/_mesh_io.py
+++ b/point_cloud_utils/_mesh_io.py
@@ -212,9 +212,8 @@ class TriangleMesh:
     def fc(self):
         return self.face_data.colors
 
-    def save(self, filename):
+    def save(self, filename, dtype=np.float32):
         from ._pcu_internal import save_mesh_internal
-        dtype = np.float64
         self.vertex_data._reset_if_none()
         self.face_data._reset_if_none()
 
@@ -238,12 +237,18 @@ class TriangleMesh:
                                       np.ones([wcolors.shape[0], wcolors.shape[1], 1], dtype=wcolors.dtype)], axis=-1)
 
         if fcolors.shape[0] > 0:
+            if fcolors.dtype == np.uint8:
+                fcolors = fcolors.astype(dtype) / 255.0
             if fcolors.max() > 1.0 or fcolors.min() < 0.0:
                 raise ValueError("Invalid values for face colors, must be between 0 and 1 (inclusive)")
         if vcolors.shape[0] > 0:
+            if vcolors.dtype == np.uint8:
+                vcolors = vcolors.astype(dtype) / 255.0
             if vcolors.max() > 1.0 or vcolors.min() < 0.0:
                 raise ValueError("Invalid values for vertex colors, must be between 0 and 1 (inclusive)")
         if wcolors.shape[0] > 0:
+            if wcolors.dtype == np.uint8:
+                wcolors = wcolors.astype(dtype) / 255.0
             if wcolors.max() > 1.0 or wcolors.min() < 0.0:
                 raise ValueError("Invalid values for wedge colors, must be between 0 and 1 (inclusive)")
 
@@ -315,7 +320,7 @@ class TriangleMesh:
 def save_triangle_mesh(filename, v, f=None,
                        vn=None, vt=None, vc=None, vq=None, vr=None, vti=None, vflags=None,
                        fn=None, fc=None, fq=None, fflags=None, wc=None, wn=None, wt=None, wti=None,
-                       textures=[], normal_maps=[]):
+                       textures=[], normal_maps=[], dtype=np.float32):
     """
     Save a triangle mesh to a file with various per-vertex, per-face, and per-wedge attributes. Each argument (except v)
     is optional and can be None.
@@ -372,38 +377,35 @@ def save_triangle_mesh(filename, v, f=None,
     mesh.textures = textures
     mesh.normal_maps = normal_maps
 
-    mesh.save(filename)
+    mesh.save(filename, dtype=dtype)
 
 
-def save_mesh_v(filename, v):
-    save_triangle_mesh(filename, v=v)
+def save_mesh_v(filename, v, dtype=np.float32):
+    save_triangle_mesh(filename, v=v, dtype=dtype)
 
 
-def save_mesh_vf(filename, v, f):
-    save_triangle_mesh(filename, v=v, f=f)
+def save_mesh_vf(filename, v, f, dtype=np.float32):
+    save_triangle_mesh(filename, v=v, f=f, dtype=dtype)
 
 
-def save_mesh_vn(filename, v, n):
-    save_triangle_mesh(filename, v=v, vn=n)
+def save_mesh_vn(filename, v, n, dtype=np.float32):
+    save_triangle_mesh(filename, v=v, vn=n, dtype=dtype)
 
 
-def save_mesh_vc(filename, v, c):
-    save_triangle_mesh(filename, v=v, vc=c)
+def save_mesh_vc(filename, v, c, dtype=np.float32):
+    save_triangle_mesh(filename, v=v, vc=c, dtype=dtype)
 
 
-def save_mesh_vnc(filename, v, n, c):
-    save_triangle_mesh(filename, v=v, vn=n, vc=c)
+def save_mesh_vnc(filename, v, n, c, dtype=np.float32):
+    save_triangle_mesh(filename, v=v, vn=n, vc=c, dtype=dtype)
 
 
-def save_mesh_vfn(filename, v, f, n):
-    save_triangle_mesh(filename, v=v, f=f, vn=n)
+def save_mesh_vfn(filename, v, f, n, dtype=np.float32):
+    save_triangle_mesh(filename, v=v, f=f, vn=n, dtype=dtype)
 
 
-def save_mesh_vfnc(filename, v, f, n, c):
-    save_triangle_mesh(filename, v=v, f=f, vn=n, vc=c)
-
-
-
+def save_mesh_vfnc(filename, v, f, n, c, dtype=np.float32):
+    save_triangle_mesh(filename, v=v, f=f, vn=n, vc=c, dtype=dtype)
 
 
 def load_triangle_mesh(filename, dtype=np.float64):

--- a/src/common/numpy_utils.h
+++ b/src/common/numpy_utils.h
@@ -1,0 +1,42 @@
+#ifndef NUMPY_UTILS_H
+#define NUMPY_UTILS_H
+
+#include <string>
+#include <vector>
+#include <npe.h>
+
+
+bool assert_shape_and_dtype(const pybind11::array& arr, std::string name, pybind11::dtype dtype,
+                            const std::vector<ssize_t>& shape) {
+    if (!arr.dtype().is(dtype)) {
+        throw pybind11::value_error("Invalid dtype for argument '" + name + "'. Expected '" +
+                                    dtype.kind() + "' but got '" + arr.dtype().kind() + "'.");
+    }
+    if (shape.size() != arr.ndim()) {
+        throw pybind11::value_error("Invalid number of dimensions for argument '" + name + "'. Expected " +
+                                    std::to_string(shape.size()) + " but got " + std::to_string(arr.ndim()) + ".");
+    }
+    bool nonempty = true;
+    for (int i = 0; i < shape.size(); i++) {
+        if (arr.shape()[i] <= 0) {
+            nonempty = false;
+        }
+        if (shape[i] < 0) {
+            if (arr.shape()[i] == 0) {
+                continue;
+            } else if (arr.shape()[i] == -shape[i]) {
+                continue;
+            }
+        } else if (shape[i] == arr.shape()[i]) {
+            continue;
+        }
+
+        throw pybind11::value_error("Invalid  shape for argument '" + name + "' at dimension " +
+                                    std::to_string(i) + ". Expected " + std::to_string(shape[i]) +
+                                    " but got " + std::to_string(arr.shape()[i]) + ".");
+    }
+
+    return nonempty;
+}
+
+#endif // NUMPY_UTILS_H

--- a/src/common/ply_loader.h
+++ b/src/common/ply_loader.h
@@ -398,7 +398,7 @@ void save_mesh_ply(std::string filename,
     for (auto kv = custom_f_attribs.begin(); kv != custom_f_attribs.end(); kv++) {
         pybind11::str key = (pybind11::str) kv->first;
         pybind11::array value = pybind11::array::ensure(kv->second);
-        if (value.shape(0) != num_vertices) {
+        if (value.shape(0) != num_faces) {
             throw pybind11::value_error("Invalid face attribute " + std::string(key) + ". Must have same number of rows as faces.");
         }
         size_t num_cols = 1;

--- a/src/common/ply_loader.h
+++ b/src/common/ply_loader.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <fstream>
 
+#define TINYPLY_IMPLEMENTATION
 #include <tinyply/source/tinyply.h>
 #include <npe.h>
 #include <npe_typedefs.h>

--- a/src/common/ply_loader.h
+++ b/src/common/ply_loader.h
@@ -1,0 +1,291 @@
+#pragma once
+
+#include <unordered_map>
+#include <fstream>
+
+#include <tinyply/source/tinyply.h>
+#include <npe.h>
+#include <npe_typedefs.h>
+#include <pybind11/stl.h>
+
+#include "common/strutil.h"
+
+
+pybind11::dtype ply_type_to_dtype(const std::shared_ptr<tinyply::PlyData> data) {
+    switch(data->t) {
+        case tinyply::Type::FLOAT32: {
+            return pybind11::dtype::of<std::float_t>();
+        }
+        case tinyply::Type::FLOAT64: {
+            return pybind11::dtype::of<std::double_t>();
+        }
+        case tinyply::Type::INT8: {
+            return pybind11::dtype::of<std::int8_t>();
+        }
+        case tinyply::Type::INT16: {
+            return pybind11::dtype::of<std::int16_t>();
+        }
+        case tinyply::Type::INT32: {
+            return pybind11::dtype::of<std::int32_t>();
+        }
+        case tinyply::Type::UINT8: {
+            return pybind11::dtype::of<std::uint8_t>();
+        }
+        case tinyply::Type::UINT16: {
+            return pybind11::dtype::of<std::uint16_t>();
+        }
+        case tinyply::Type::UINT32: {
+            return pybind11::dtype::of<std::uint32_t>();
+        }
+        default: {
+            throw std::runtime_error("Internal PLY loading error. Cannot determine type.");
+        }
+
+    };
+}
+
+
+pybind11::array ply_data_to_array(std::shared_ptr<tinyply::PlyData> attrib) {
+    pybind11::dtype attrib_dtype = ply_type_to_dtype(attrib);
+    if (attrib->count == 0) {
+        return pybind11::array(attrib_dtype, std::vector<size_t>({0, 0}));
+    }
+    size_t bytes_per_scalar = attrib_dtype.elsize();
+    if (bytes_per_scalar <= 0) {
+        throw std::runtime_error("Internal PLY loading error. Type has no defined byte size.");
+    }
+    size_t numel = attrib->buffer.size_bytes() / bytes_per_scalar;
+    size_t num_rows = attrib->count;
+    size_t num_cols = numel / num_rows;
+    if (attrib->buffer.size_bytes() != num_rows * num_cols * bytes_per_scalar) {
+        throw std::runtime_error("PLY loading internal error");
+    }
+    pybind11::array attrib_array(attrib_dtype, std::vector<size_t>({num_rows, num_cols}));
+    std::memcpy(attrib_array.mutable_data(), attrib->buffer.get(), attrib->buffer.size_bytes());
+    return attrib_array;
+}
+
+std::shared_ptr<tinyply::PlyData> request_properties_from_element(
+        tinyply::PlyFile& ply_file,
+        std::unordered_map<std::string, std::set<std::string>>& loaded_properties,
+        std::string elementKey, const std::vector<std::string> property_keys,
+        const uint32_t list_size_hint = 0, std::string error_message = "") {
+    std::shared_ptr<tinyply::PlyData> ret;
+    try {
+        ret = ply_file.request_properties_from_element(elementKey, property_keys, list_size_hint);
+        for (int i = 0; i < property_keys.size(); i++) {
+            loaded_properties[elementKey].insert(property_keys[i]);
+        }
+    } catch (const std::exception & e) {
+        ret = nullptr;
+        if (error_message != "") {
+            throw std::runtime_error(error_message);
+        }
+    }
+    return ret;
+}
+
+
+void load_mesh_ply(const std::string& filename, std::unordered_map<std::string, pybind11::object>& ret) {
+    tinyply::PlyFile plyf;
+    std::ifstream filestream (filename, std::ifstream::binary);
+
+    plyf.parse_header(filestream);
+
+    // Track baked in properties which we've already loaded so we don't load them twice
+    std::unordered_map<std::string, std::set<std::string>> loaded_properties;
+    loaded_properties["vertex"] = std::set<std::string>();
+    loaded_properties["face"] = std::set<std::string>();
+
+    // Set up loaders for baked in properties
+    auto vertex_pos_ptr = request_properties_from_element(
+            plyf, loaded_properties,
+            "vertex", { "x", "y", "z" }, 0,
+            "PLY file has no vertex positions.");
+    auto vertex_normals_ptr = request_properties_from_element(
+            plyf, loaded_properties,"vertex", { "nx", "ny", "nz" });
+    auto vertex_colors_ptr = request_properties_from_element(
+            plyf, loaded_properties,"vertex", { "red", "green", "blue" });
+    auto vertex_alpha_ptr = request_properties_from_element(
+            plyf, loaded_properties,"vertex", { "alpha" });
+    auto vertex_quality_ptr = request_properties_from_element(
+            plyf, loaded_properties,"vertex", { "quality" });
+    auto vertex_radius_ptr = request_properties_from_element(
+            plyf, loaded_properties,"vertex", { "radius" });
+    auto vertex_flags_ptr = request_properties_from_element(
+            plyf, loaded_properties,"face", { "flags" });
+    std::shared_ptr<tinyply::PlyData> vertex_texcoord_ptr;
+    try {
+        vertex_texcoord_ptr = request_properties_from_element(
+                plyf, loaded_properties, "vertex", { "s", "t" }, 0, "no ST");
+    } catch (const std::exception & e) {
+        try {
+            vertex_texcoord_ptr = request_properties_from_element(
+                    plyf, loaded_properties, "vertex", { "u", "v" }, 0, "no UV");
+        } catch (const std::exception& e) {
+            vertex_texcoord_ptr = request_properties_from_element(
+                        plyf, loaded_properties, "vertex", { "texcoord" }, 0);
+        }
+    }
+
+    auto face_indices_ptr = request_properties_from_element(
+            plyf, loaded_properties, "face", { "vertex_indices" });
+    auto face_flags_ptr = request_properties_from_element(
+            plyf, loaded_properties, "face", { "flags" });
+    auto face_colors_ptr = request_properties_from_element(
+            plyf, loaded_properties, "face", { "red", "green", "blue" });
+    auto face_alpha_ptr = request_properties_from_element(
+            plyf, loaded_properties, "face", { "alpha" });
+    auto face_quality_ptr = request_properties_from_element(
+            plyf, loaded_properties, "face", { "quality" });
+    auto face_normals_ptr = request_properties_from_element(
+            plyf, loaded_properties, "face", { "nx", "ny", "nz" });
+    auto wedge_texindex_ptr = request_properties_from_element(
+            plyf, loaded_properties, "face", { "texnumber" });
+    std::shared_ptr<tinyply::PlyData> wedge_texcoords_ptr;
+    try {
+        wedge_texcoords_ptr = request_properties_from_element(
+                plyf, loaded_properties, "face", { "s", "t" }, 0, "no ST");
+    } catch (const std::exception & e) {
+        try {
+            wedge_texcoords_ptr = request_properties_from_element(
+                    plyf, loaded_properties, "face", { "u", "v" }, 0, "no UV");
+        } catch (const std::exception & e) {
+            wedge_texcoords_ptr = request_properties_from_element(
+                    plyf, loaded_properties, "face", { "texcoord" }, 0);
+        }
+
+    }
+
+    // Load paths to texture and normal maps files
+    std::vector<std::string> texture_files;
+    std::vector<std::string> normal_maps;
+    for (const auto & c : plyf.get_comments()) {
+        std::string trimmed = strutil::trim_copy(c);
+        if (strutil::starts_with(strutil::to_lower(trimmed), "texturefile")) {
+            std::string tex_filepath = strutil::trim_copy(trimmed.substr(11));
+            texture_files.push_back(tex_filepath);
+        }
+        // std::cout << "\t[ply_header] Comment: " << c << std::endl;
+    }
+
+    // Set up loaders for custom vertex and face attributes
+    std::vector<std::pair<std::string, std::shared_ptr<tinyply::PlyData>>> custom_vertex_attribs;
+    std::vector<std::pair<std::string, std::shared_ptr<tinyply::PlyData>>> custom_face_attribs;
+    for (const auto & e : plyf.get_elements()) {
+        // std::cout << "\t[ply_header] element: " << e.name << " (" << e.size << ")" << std::endl;
+        if (e.name != "vertex" && e.name != "face") {
+            std::cerr << "Warning: Element [" << e.name << "] is not supported and will be ignored" << std::endl;
+            continue;
+        }
+
+        for (const auto & p : e.properties) {
+            // std::cout << "\t[ply_header] \tproperty: " << p.name << " (type=" << tinyply::PropertyTable[p.propertyType].str << ")";
+            if (loaded_properties[e.name].find(p.name) == loaded_properties[e.name].end()) {
+                if (e.name == "vertex") {
+                    std::shared_ptr<tinyply::PlyData> dataptr;
+                    if (p.isList) {
+                        dataptr = plyf.request_properties_from_element(e.name, { p.name }, p.listCount);
+                    } else {
+                        dataptr = plyf.request_properties_from_element(e.name, { p.name });
+                    }
+                    custom_vertex_attribs.push_back(std::make_pair(p.name, dataptr));
+                } else {
+                    std::shared_ptr<tinyply::PlyData> dataptr;
+                    if (p.isList) {
+                        dataptr = plyf.request_properties_from_element(e.name, { p.name }, p.listCount);
+                    } else {
+                        dataptr = plyf.request_properties_from_element(e.name, { p.name });
+                    }
+                    custom_face_attribs.push_back(std::make_pair(p.name, dataptr));
+                }
+            }
+            // if (p.isList) { std::cout << " (list_type=" << tinyply::PropertyTable[p.listType].str << ")"; }
+            // std::cout << std::endl;
+        }
+    }
+
+    plyf.read(filestream);
+
+    std::unordered_map<std::string, pybind11::object> vertex_attribs;
+    for (int i = 0; i < custom_vertex_attribs.size(); i += 1) {
+        std::string attrib_name = custom_vertex_attribs[i].first;
+        std::shared_ptr<tinyply::PlyData> attrib = custom_vertex_attribs[i].second;
+        vertex_attribs.insert(std::make_pair(attrib_name, (pybind11::object) ply_data_to_array(attrib)));
+    }
+
+    std::unordered_map<std::string, pybind11::object> face_attribs;
+    for (int i = 0; i < custom_face_attribs.size(); i += 1) {
+        std::string attrib_name = custom_face_attribs[i].first;
+        std::shared_ptr<tinyply::PlyData> attrib = custom_face_attribs[i].second;
+        face_attribs.insert(std::make_pair(attrib_name, (pybind11::object) ply_data_to_array(attrib)));
+    }
+
+    std::unordered_map<std::string, pybind11::object> vertex_ret;
+    if (vertex_pos_ptr) {
+        vertex_ret.insert(std::make_pair("positions", (pybind11::object) ply_data_to_array(vertex_pos_ptr)));
+    }
+    if (vertex_normals_ptr) {
+        vertex_ret.insert(std::make_pair("normals", (pybind11::object) ply_data_to_array(vertex_normals_ptr)));
+    }
+    if (vertex_colors_ptr) {
+        vertex_ret.insert(std::make_pair("colors", (pybind11::object) ply_data_to_array(vertex_colors_ptr)));
+    }
+    if (vertex_texcoord_ptr) {
+        vertex_ret.insert(std::make_pair("texcoords", (pybind11::object) ply_data_to_array(vertex_texcoord_ptr)));
+    }
+    if (vertex_alpha_ptr) {
+        vertex_ret.insert(std::make_pair("alpha", (pybind11::object) ply_data_to_array(vertex_alpha_ptr)));
+    }
+    if (vertex_flags_ptr) {
+        vertex_ret.insert(std::make_pair("flags", (pybind11::object) ply_data_to_array(vertex_flags_ptr)));
+    }
+    if (vertex_quality_ptr) {
+        vertex_ret.insert(std::make_pair("quality", (pybind11::object) ply_data_to_array(vertex_quality_ptr)));
+    }
+    if (vertex_radius_ptr) {
+        vertex_ret.insert(std::make_pair("radius", (pybind11::object) ply_data_to_array(vertex_radius_ptr)));
+    }
+
+    std::unordered_map<std::string, pybind11::object> face_ret;
+    if (face_indices_ptr) {
+        face_ret.insert(std::make_pair("vertex_ids", (pybind11::object) ply_data_to_array(face_indices_ptr)));
+    }
+    if (face_flags_ptr) {
+        face_ret.insert(std::make_pair("flags", (pybind11::object) ply_data_to_array(face_flags_ptr)));
+    }
+    if (face_colors_ptr) {
+        face_ret.insert(std::make_pair("colors", (pybind11::object) ply_data_to_array(face_colors_ptr)));
+    }
+    if (face_alpha_ptr) {
+        face_ret.insert(std::make_pair("alpha", (pybind11::object) ply_data_to_array(face_alpha_ptr)));
+    }
+    if (face_quality_ptr) {
+        face_ret.insert(std::make_pair("quality", (pybind11::object) ply_data_to_array(face_quality_ptr)));
+    }
+    if (face_normals_ptr) {
+        face_ret.insert(std::make_pair("normals", (pybind11::object) ply_data_to_array(face_normals_ptr)));
+    }
+    if (wedge_texindex_ptr) {
+        face_ret.insert(std::make_pair("wedge_tex_ids", (pybind11::object) ply_data_to_array(wedge_texindex_ptr)));
+    }
+    if (wedge_texcoords_ptr) {
+        pybind11::array wedge_texcoords_array = ply_data_to_array(wedge_texcoords_ptr);
+        wedge_texcoords_array.resize(std::vector<size_t>({(size_t) wedge_texcoords_array.shape(0), 3, 2}));
+        face_ret.insert(std::make_pair("wedge_texcoords", (pybind11::object) wedge_texcoords_array));
+    }
+
+    vertex_ret["custom_attributes"] = pybind11::cast(vertex_attribs);
+    pybind11::dict ret_vertex_data = pybind11::cast(vertex_ret);
+
+    face_ret["custom_attributes"] = pybind11::cast(face_attribs);
+    pybind11::dict ret_face_data = pybind11::cast(face_ret);
+    pybind11::list ret_normalmaps = pybind11::list();
+    pybind11::list ret_textures = pybind11::cast(texture_files);
+
+    ret["vertex_data"] = ret_vertex_data;
+    ret["face_data"] = ret_face_data;
+    ret["textures"] = ret_textures;
+    ret["normal_maps"] = ret_normalmaps;
+}
+

--- a/src/common/strutil.h
+++ b/src/common/strutil.h
@@ -16,7 +16,8 @@
  ******************************************************************************
  */
 
-#pragma once
+#ifndef STRUTIL_H
+#define STRUTIL_H
 
 #include <algorithm>
 #include <cctype>
@@ -607,3 +608,6 @@ namespace strutil
         return strs;
     }
 }
+
+
+#endif  // STRUTIL_H

--- a/src/common/strutil.h
+++ b/src/common/strutil.h
@@ -1,0 +1,609 @@
+ /**
+ ******************************************************************************
+ *
+ *  @mainpage strutil v1.0.1 - header-only string utility library documentation
+ *  @see https://github.com/Shot511/strutil
+ *
+ *  @copyright  Copyright (C) 2020 Tomasz Galaj (Shot511)
+ *  @file       strutil.h
+ *  @brief      Library public interface header
+ *
+ *  @subsection Thank you for your contributions:
+ *              - SomeRandomDev49
+ *              - flying-tiger
+ * 
+ *
+ ******************************************************************************
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+//! The strutil namespace
+namespace strutil
+{
+    /**
+     * @brief Converts any datatype into std::string.
+     *        Datatype must support << operator.
+     * @tparam T
+     * @param value - will be converted into std::string.
+     * @return Converted value as std::string.
+     */
+    template<typename T>
+    static inline std::string to_string(T value)
+    {
+        std::stringstream ss;
+        ss << value;
+
+        return ss.str();
+    }
+
+    /**
+     * @brief Converts std::string into any datatype.
+     *        Datatype must support << operator.
+     * @tparam T
+     * @param str - std::string that will be converted into datatype T.
+     * @return Variable of datatype T.
+     */
+    template<typename T>
+    static inline T parse_string(const std::string & str)
+    {
+        T result;
+        std::istringstream(str) >> result;
+
+        return result;
+    }
+
+    /**
+     * @brief Converts std::string to lower case.
+     * @param str - std::string that needs to be converted.
+     * @return Lower case input std::string.
+     */
+    static inline std::string to_lower(const std::string & str)
+    {
+        auto result = str;
+        std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) -> unsigned char
+        {
+            return static_cast<unsigned char>(std::tolower(c));
+        });
+
+        return result;
+    }
+
+    /**
+     * @brief Converts std::string to upper case.
+     * @param str - std::string that needs to be converted.
+     * @return Upper case input std::string.
+     */
+    static inline std::string to_upper(const std::string & str)
+    {
+        auto result = str;
+        std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) -> unsigned char
+        {
+            return static_cast<unsigned char>(std::toupper(c));
+        });
+
+        return result;
+    }
+
+    /**
+     * @brief Converts the first character of a string to uppercase letter and lowercases all other characters, if any.
+     * @param str - input string to be capitalized.
+     * @return A string with the first letter capitalized and all other characters lowercased. It doesn't modify the input string.
+     */
+    static inline std::string capitalize(const std::string & str)
+    {
+        auto result = str;
+        result[0] = std::toupper(result[0]);
+
+        return result;
+    }
+
+    /**
+     * @brief Converts only the first character of a string to uppercase letter, all other characters stay unchanged.
+     * @param str - input string to be modified.
+     * @return A string with the first letter capitalized. All other characters stay unchanged. It doesn't modify the input string.
+     */
+    static inline std::string capitalize_first_char(const std::string & str)
+    {
+        auto result = to_lower(str);
+        result[0] = std::toupper(result[0]);
+
+        return result;
+    }
+
+    /**
+     * @brief Checks if input std::string str contains specified substring.
+     * @param str - std::string to be checked.
+     * @param substring - searched substring.
+     * @return True if substring was found in str, false otherwise.
+     */
+    static inline bool contains(const std::string & str, const std::string & substring)
+    {
+        return str.find(substring) != std::string::npos;
+    }
+
+    /**
+     * @brief Checks if input std::string str contains specified character.
+     * @param str - std::string to be checked.
+     * @param character - searched character.
+     * @return True if character was found in str, false otherwise.
+     */
+    static inline bool contains(const std::string & str, const char character)
+    {
+        return contains(str, std::string(1,character));
+    }
+
+    /**
+     * @brief Compares two std::strings ignoring their case (lower/upper).
+     * @param str1 - std::string to compare
+     * @param str2 - std::string to compare
+     * @return True if str1 and str2 are equal, false otherwise.
+     */
+    static inline bool compare_ignore_case(const std::string & str1, const std::string & str2)
+    {
+        return to_lower(str1) == to_lower(str2);
+    }
+
+    /**
+     * @brief Trims (in-place) white spaces from the left side of std::string.
+     *        Taken from: http://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring.
+     * @param str - input std::string to remove white spaces from.
+     */
+    static inline void trim_left(std::string & str)
+    {
+        str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int ch) { return !std::isspace(ch); }));
+    }
+
+    /**
+     * @brief Trims (in-place) white spaces from the right side of std::string.
+     *        Taken from: http://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring.
+     * @param str - input std::string to remove white spaces from.
+     */
+    static inline void trim_right(std::string & str)
+    {
+        str.erase(std::find_if(str.rbegin(), str.rend(), [](int ch) { return !std::isspace(ch); }).base(), str.end());
+    }
+
+    /**
+     * @brief Trims (in-place) white spaces from the both sides of std::string.
+     *        Taken from: http://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring.
+     * @param str - input std::string to remove white spaces from.
+     */
+    static inline void trim(std::string & str)
+    {
+        trim_left(str);
+        trim_right(str);
+    }
+
+     /**
+      * @brief Trims white spaces from the left side of std::string.
+      *        Taken from: http://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring.
+      * @param str - input std::string to remove white spaces from.
+      * @return Copy of input str with trimmed white spaces.
+      */
+    static inline std::string trim_left_copy(std::string str)
+    {
+        trim_left(str);
+        return str;
+    }
+
+    /**
+      * @brief Trims white spaces from the right side of std::string.
+      *        Taken from: http://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring.
+      * @param str - input std::string to remove white spaces from.
+      * @return Copy of input str with trimmed white spaces.
+      */
+    static inline std::string trim_right_copy(std::string str)
+    {
+        trim_right(str);
+        return str;
+    }
+
+    /**
+      * @brief Trims white spaces from the both sides of std::string.
+      *        Taken from: http://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring.
+      * @param str - input std::string to remove white spaces from.
+      * @return Copy of input str with trimmed white spaces.
+      */
+    static inline std::string trim_copy(std::string str)
+    {
+        trim(str);
+        return str;
+    }
+
+    /**
+     * @brief Replaces (in-place) the first occurance of target with replacement.
+     *        Taken from: http://stackoverflow.com/questions/3418231/c-replace-part-of-a-string-with-another-string.
+     * @param str - input std::string that will be modified.
+     * @param target - substring that will be replaced with replacement.
+     * @param replecament - substring that will replace target.
+     * @return True if replacement was successfull, false otherwise.
+     */
+    static inline bool replace_first(std::string & str, const std::string & target, const std::string & replecament)
+    {
+        size_t start_pos = str.find(target);
+        if (start_pos == std::string::npos)
+        {
+            return false;
+        }
+
+        str.replace(start_pos, target.length(), replecament);
+        return true;
+    }
+
+    /**
+     * @brief Replaces (in-place) last occurance of target with replacement.
+     *        Taken from: http://stackoverflow.com/questions/3418231/c-replace-part-of-a-string-with-another-string.
+     * @param str - input std::string that will be modified.
+     * @param target - substring that will be replaced with replacement.
+     * @param replecament - substring that will replace target.
+     * @return True if replacement was successfull, false otherwise.
+     */
+    static inline bool replace_last(std::string & str, const std::string & target, const std::string & replecament)
+    {
+        size_t start_pos = str.rfind(target);
+        if (start_pos == std::string::npos)
+        {
+            return false;
+        }
+
+        str.replace(start_pos, target.length(), replecament);
+        return true;
+    }
+
+    /**
+     * @brief Replaces (in-place) all occurances of target with replacement.
+     *        Taken from: http://stackoverflow.com/questions/3418231/c-replace-part-of-a-string-with-another-string.
+     * @param str - input std::string that will be modified.
+     * @param target - substring that will be replaced with replacement.
+     * @param replecament - substring that will replace target.
+     * @return True if replacement was successfull, false otherwise.
+     */
+    static inline bool replace_all(std::string & str, const std::string & target, const std::string & replecament)
+    {
+        if (target.empty())
+        {
+            return false;
+        }
+
+        size_t start_pos = 0;
+        const bool found_substring = str.find(target, start_pos) != std::string::npos;
+
+        while ((start_pos = str.find(target, start_pos)) != std::string::npos)
+        {
+            str.replace(start_pos, target.length(), replecament);
+            start_pos += replecament.length();
+        }
+
+        return found_substring;
+    }
+
+    /**
+     * @brief Checks if std::string str ends with specified suffix.
+     * @param str - input std::string that will be checked.
+     * @param suffix - searched suffix in str.
+     * @return True if suffix was found, false otherwise.
+     */
+    static inline bool ends_with(const std::string & str, const std::string & suffix)
+    {
+        const auto pos = str.rfind(suffix);
+
+        return (pos != std::string::npos) && (pos == (str.length() - suffix.length()));
+    }
+
+    /**
+     * @brief Checks if std::string str ends with specified character.
+     * @param str - input std::string that will be checked.
+     * @param suffix - searched character in str.
+     * @return True if ends with character, false otherwise.
+     */
+    static inline bool ends_with(const std::string & str, const char suffix)
+    {
+        return (str.size() > 0) && (*(str.end()-1) == suffix);
+    }
+
+    /**
+     * @brief Checks if std::string str starts with specified prefix.
+     * @param str - input std::string that will be checked.
+     * @param prefix - searched prefix in str.
+     * @return True if prefix was found, false otherwise.
+     */
+    static inline bool starts_with(const std::string & str, const std::string & prefix)
+    {
+        return str.find(prefix) == 0;
+    }
+
+    /**
+     * @brief Checks if std::string str starts with specified character.
+     * @param str - input std::string that will be checked.
+     * @param prefix - searched character in str.
+     * @return True if starts with character, false otherwise.
+     */
+    static inline bool starts_with(const std::string & str, const char prefix)
+    {
+        return (str.size() > 0) && (str[0] == prefix);
+    }
+
+    /**
+     * @brief Splits input std::string str according to input delim.
+     * @param str - std::string that will be splitted.
+     * @param delim - the delimiter.
+     * @return std::vector<std::string> that contains all splitted tokens.
+     */
+    static inline std::vector<std::string> split(const std::string & str, const char delim)
+    {
+        std::vector<std::string> tokens;
+        std::stringstream ss(str);
+
+        std::string token;
+        while(std::getline(ss, token, delim))
+        {
+            tokens.push_back(token);
+        }
+
+        // Match semantics of split(str,str)
+        if (str.size() == 0 || ends_with(str, delim)) {
+            tokens.push_back("");
+        }
+
+        return tokens;
+    }
+
+    /**
+     * @brief Splits input std::string str according to input std::string delim.
+     *        Taken from: https://stackoverflow.com/a/46931770/1892346.
+     * @param str - std::string that will be split.
+     * @param delim - the delimiter.
+     * @return std::vector<std::string> that contains all splitted tokens.
+     */
+    static inline std::vector<std::string> split(const std::string & str, const std::string & delim)
+    {
+        size_t pos_start = 0, pos_end, delim_len = delim.length();
+        std::string token;
+        std::vector<std::string> tokens;
+
+        while ((pos_end = str.find(delim, pos_start)) != std::string::npos)
+        {
+            token = str.substr(pos_start, pos_end - pos_start);
+            pos_start = pos_end + delim_len;
+            tokens.push_back(token);
+        }
+
+        tokens.push_back(str.substr(pos_start));
+        return tokens;
+    }
+
+    /**
+     * @brief Splits input string using regex as a delimiter.
+     * @param src - std::string that will be split.
+     * @param rgx_str - the set of delimiter characters.
+     * @return vector of resulting tokens.
+     */
+    static inline std::vector<std::string> regex_split(const std::string& src, std::string rgx_str)
+    {
+        std::vector<std::string> elems;
+        std::regex rgx(rgx_str);
+        std::sregex_token_iterator iter(src.begin(), src.end(), rgx, -1);
+        std::sregex_token_iterator end;
+        while (iter != end)
+        {
+            elems.push_back(*iter);
+            ++iter;
+        }
+        return elems;
+    }
+
+    /**
+     * @brief Splits input string using regex as a delimiter.
+     * @param src - std::string that will be split.
+     * @param dest - map of matched delimiter and those being splitted.
+     * @param rgx_str - the set of delimiter characters.
+     * @return True if the parsing is successfully done.
+     */
+    static inline std::map<std::string, std::string> regex_split_map(const std::string& src, std::string rgx_str)
+    {
+        std::map<std::string, std::string> dest;
+        std::string tstr = src + " ";
+        std::regex rgx(rgx_str);
+        std::sregex_token_iterator niter(tstr.begin(), tstr.end(), rgx);
+        std::sregex_token_iterator viter(tstr.begin(), tstr.end(), rgx, -1);
+        std::sregex_token_iterator end;
+        ++viter;
+        while (niter != end)
+        {
+            dest[*niter] = *viter;
+            ++niter;
+            ++viter;
+        }
+
+        return dest;
+    }
+
+    /**
+     * @brief Splits input string using any delimiter in the given set.
+     * @param str - std::string that will be split.
+     * @param delims - the set of delimiter characters.
+     * @return vector of resulting tokens.
+     */
+    static inline std::vector<std::string> split_any(const std::string & str, const std::string & delims)
+    {
+        std::string token;
+        std::vector<std::string> tokens;
+
+        size_t pos_start = 0;
+        for (size_t pos_end = 0; pos_end < str.length(); ++pos_end)
+        {
+            if (contains(delims, str[pos_end]))
+            {
+                token = str.substr(pos_start, pos_end - pos_start);
+                tokens.push_back(token);
+                pos_start = pos_end + 1;
+            }
+        }
+
+        tokens.push_back(str.substr(pos_start));
+        return tokens;
+    }
+
+    /**
+     * @brief Joins all elements of std::vector tokens of arbitrary datatypes
+     *        into one std::string with delimiter delim.
+     * @tparam T - arbitrary datatype.
+     * @param tokens - vector of tokens.
+     * @param delim - the delimiter.
+     * @return std::string with joined elements of vector tokens with delimiter delim.
+     */
+    template<typename T>
+    static inline std::string join(const std::vector<T> & tokens, const std::string & delim)
+    {
+        std::ostringstream result;
+        for(auto it = tokens.begin(); it != tokens.end(); ++it)
+        {
+            if(it != tokens.begin())
+            {
+                result << delim;
+            }
+
+            result << *it;
+        }
+
+        return result.str();
+    }
+
+    /**
+     * @brief Inplace removal of all empty strings in a vector<string>
+     * @param tokens - vector of strings.
+     */
+    static inline void drop_empty(std::vector<std::string> & tokens)
+    {
+        auto last = std::remove_if(tokens.begin(), tokens.end(),
+                                   [](const std::string& s){ return s.size() == 0; });
+        tokens.erase(last, tokens.end());
+    }
+
+    /**
+     * @brief Inplace removal of all empty strings in a vector<string>
+     * @param tokens - vector of strings.
+     * @return vector of non-empty tokens.
+     */
+    static inline std::vector<std::string> drop_empty_copy(std::vector<std::string> tokens)
+    {
+        drop_empty(tokens);
+        return tokens;
+    }
+
+    /**
+     * @brief Inplace removal of all duplicate strings in a vector<string> where order is not to be maintained
+     *        Taken from: C++ Primer V5
+     * @param tokens - vector of strings.
+     * @return vector of non-duplicate tokens.
+     */
+    static inline void drop_duplicate(std::vector<std::string> &tokens)
+    {
+        std::sort(tokens.begin(), tokens.end());
+        auto end_unique = std::unique(tokens.begin(), tokens.end());
+        tokens.erase(end_unique, tokens.end());
+    }
+
+    /**
+     * @brief Removal of all duplicate strings in a vector<string> where order is not to be maintained
+     *        Taken from: C++ Primer V5
+     * @param tokens - vector of strings.
+     * @return vector of non-duplicate tokens.
+     */
+    static inline std::vector<std::string> drop_duplicate_copy(std::vector<std::string> tokens)
+    {
+        std::sort(tokens.begin(), tokens.end());
+        auto end_unique = std::unique(tokens.begin(), tokens.end());
+        tokens.erase(end_unique, tokens.end());
+        return tokens;
+    }
+
+    /**
+     * @brief Creates new std::string with repeated n times substring str.
+     * @param str - substring that needs to be repeated.
+     * @param n - number of iterations.
+     * @return std::string with repeated substring str.
+     */
+    static inline std::string repeat(const std::string & str, unsigned n)
+    {
+        std::string result;
+
+        for(unsigned i = 0; i < n; ++i)
+        {
+            result += str;
+        }
+
+        return result;
+    }
+
+    /**
+     * @brief Creates new std::string with repeated n times char c.
+     * @param c - char that needs to be repeated.
+     * @param n - number of iterations.
+     * @return std::string with repeated char c.
+     */
+    static inline std::string repeat(char c, unsigned n)
+    {
+        return std::string(n, c);
+    }
+
+    /**
+     * @brief Checks if input std::string str matches specified reular expression regex.
+     * @param str - std::string to be checked.
+     * @param regex - the std::regex regular expression.
+     * @return True if regex matches str, false otherwise.
+     */
+    static inline bool matches(const std::string & str, const std::regex & regex)
+    {
+        return std::regex_match(str, regex);
+    }
+
+    /**
+     * @brief Sort input std::vector<std::string> strs in ascending order.
+     * @param strs - std::vector<std::string> to be checked.
+     */
+    template<typename T>
+    static inline void sorting_ascending(std::vector<T> &strs)
+    {
+        std::sort(strs.begin(), strs.end());
+    }
+
+    /**
+     * @brief Sorted input std::vector<std::string> strs in descending order.
+     * @param strs - std::vector<std::string> to be checked.
+     */
+    template<typename T>
+    static inline void sorting_descending(std::vector<T> &strs)
+    {
+        std::sort(strs.begin(),strs.end(), std::greater<T>());
+    }
+
+    /**
+     * @brief Reverse input std::vector<std::string> strs.
+     * @param strs - std::vector<std::string> to be checked.
+     */
+    template<typename T>
+    static inline void reverse_inplace(std::vector<T> &strs)
+    {
+        std::reverse(strs.begin(), strs.end());
+    }
+
+    /**
+     * @brief Reverse input std::vector<std::string> strs.
+     * @param strs - std::vector<std::string> to be checked.
+     */
+    template<typename T>
+    static inline std::vector<T> reverse_copy(std::vector<T> strs)
+    {
+        std::reverse(strs.begin(), strs.end());
+        return strs;
+    }
+}

--- a/src/meshio.cpp
+++ b/src/meshio.cpp
@@ -18,6 +18,7 @@
 #include "common/common.h"
 #include "common/strutil.h"
 #include "common/ply_loader.h"
+#include "common/numpy_utils.h"
 
 
 namespace {
@@ -49,39 +50,6 @@ typedef CMesh::VertexIterator VertexIterator;
 typedef CMesh::FaceContainer FaceContainer;
 typedef CMesh::ScalarType ScalarType;
 
-
-bool assert_shape_and_dtype(const pybind11::array& arr, std::string name, pybind11::dtype dtype,
-                            const std::vector<ssize_t>& shape) {
-    if (!arr.dtype().is(dtype)) {
-        throw pybind11::value_error("Invalid dtype for argument '" + name + "'. Expected '" +
-                                    dtype.kind() + "' but got '" + arr.dtype().kind() + "'.");
-    }
-    if (shape.size() != arr.ndim()) {
-        throw pybind11::value_error("Invalid number of dimensions for argument '" + name + "'. Expected " +
-                                    std::to_string(shape.size()) + " but got " + std::to_string(arr.ndim()) + ".");
-    }
-    bool nonempty = true;
-    for (int i = 0; i < shape.size(); i++) {
-        if (arr.shape()[i] <= 0) {
-            nonempty = false;
-        }
-        if (shape[i] < 0) {
-            if (arr.shape()[i] == 0) {
-                continue;
-            } else if (arr.shape()[i] == -shape[i]) {
-                continue;
-            }
-        } else if (shape[i] == arr.shape()[i]) {
-            continue;
-        }
-
-        throw pybind11::value_error("Invalid  shape for argument '" + name + "' at dimension " +
-                                    std::to_string(i) + ". Expected " + std::to_string(shape[i]) +
-                                    " but got " + std::to_string(arr.shape()[i]) + ".");
-    }
-
-    return nonempty;
-}
 
 template <typename Scalar>
 void load_mesh_vcg(CMesh& m, int mask, std::unordered_map<std::string, pybind11::object>& ret) {
@@ -625,6 +593,9 @@ npe_arg(w_normals, pybind11::array)
 npe_arg(w_texcoords, pybind11::array)
 npe_arg(w_texids, pybind11::array)
 
+npe_arg(custom_v_attribs, pybind11::dict)
+npe_arg(custom_f_attribs, pybind11::dict)
+
 npe_arg(textures, std::vector<std::string>)
 npe_arg(normal_maps, std::vector<std::string>)
 
@@ -633,27 +604,83 @@ npe_arg(dtype_i, npe::dtype)
 
 npe_begin_code()
 {
-    write_mesh_vcg<double, int>(filename,
-                   v_positions,
-                   v_normals,
-                   v_texcoords,
-                   v_colors,
-                   v_quality,
-                   v_radius,
-                   v_texids,
-                   v_flags,
-                   f_vertex_ids,
-                   f_normals,
-                   f_colors,
-                   f_quality,
-                   f_flags,
-                   w_colors,
-                   w_normals,
-                   w_texcoords,
-                   w_texids,
-                   textures,
-                   normal_maps,
-                   dtype_f,
-                   dtype_i);
+    if (strutil::ends_with(strutil::to_lower(strutil::trim_copy(filename)), "ply")) {
+        save_mesh_ply(filename,
+                      v_positions,
+                      v_normals,
+                      v_texcoords,
+                      v_colors,
+                      v_quality,
+                      v_radius,
+                      v_texids,
+                      v_flags,
+                      f_vertex_ids,
+                      f_normals,
+                      f_colors,
+                      f_quality,
+                      f_flags,
+                      w_colors,
+                      w_normals,
+                      w_texcoords,
+                      w_texids,
+                      custom_v_attribs,
+                      custom_f_attribs,
+                      textures,
+                      normal_maps,
+                      dtype_f,
+                      dtype_i);
+        return;
+    }
+
+    if (dtype_f.equal(pybind11::dtype::of<std::float_t>())) {
+        write_mesh_vcg<float, int>(filename,
+                                   v_positions,
+                                   v_normals,
+                                   v_texcoords,
+                                   v_colors,
+                                   v_quality,
+                                   v_radius,
+                                   v_texids,
+                                   v_flags,
+                                   f_vertex_ids,
+                                   f_normals,
+                                   f_colors,
+                                   f_quality,
+                                   f_flags,
+                                   w_colors,
+                                   w_normals,
+                                   w_texcoords,
+                                   w_texids,
+                                   textures,
+                                   normal_maps,
+                                   dtype_f,
+                                   dtype_i);
+    } else if (dtype_f.equal(pybind11::dtype::of<std::double_t>())) {
+        write_mesh_vcg<double, int>(filename,
+                                    v_positions,
+                                    v_normals,
+                                    v_texcoords,
+                                    v_colors,
+                                    v_quality,
+                                    v_radius,
+                                    v_texids,
+                                    v_flags,
+                                    f_vertex_ids,
+                                    f_normals,
+                                    f_colors,
+                                    f_quality,
+                                    f_flags,
+                                    w_colors,
+                                    w_normals,
+                                    w_texcoords,
+                                    w_texids,
+                                    textures,
+                                    normal_maps,
+                                    dtype_f,
+                                    dtype_i);
+    } else {
+        throw pybind11::value_error("Invalid dtype in save_mesh");
+    }
+
 }
 npe_end_code()

--- a/src/meshio.cpp
+++ b/src/meshio.cpp
@@ -16,6 +16,9 @@
 #include <pybind11/stl.h>
 
 #include "common/common.h"
+#include "common/strutil.h"
+#include "common/ply_loader.h"
+
 
 namespace {
 
@@ -558,6 +561,11 @@ npe_arg(filename, std::string)
 npe_default_arg(dtype, npe::dtype, "float64")
 npe_begin_code()
 {
+    if (strutil::ends_with(strutil::to_lower(strutil::trim_copy(filename)), "ply")) {
+        std::unordered_map<std::string, pybind11::object> ret;
+        load_mesh_ply(filename, ret);
+        return ret;
+    }
     CMesh m;
     int mask = 0;
     tri::io::Importer<CMesh>::LoadMask(filename.c_str(), mask);

--- a/src/meshio.cpp
+++ b/src/meshio.cpp
@@ -1,10 +1,3 @@
-#include <igl/readOBJ.h>
-#include <igl/readPLY.h>
-#include <igl/readOFF.h>
-#include <igl/writeOBJ.h>
-#include <igl/writePLY.h>
-#include <igl/writeOFF.h>
-
 #include <unordered_map>
 
 #include <vcg/complex/complex.h>


### PR DESCRIPTION
Rewrite PLY loader using [tinyply](https://github.com/ddiakopoulos/tinyply) and enable support for custom vertex and face attributes in addition to default attributes. 

This PR also allows for saving scalars in float32. 

The vcglib loaders are actually kind of bad (struct of arrays, code is really hard to follow). Eventually, I'd like to replace all the loading backends using more modern solutions.