### PR TITLE
Ignore geogram for MacOS

### DIFF
--- a/.github/workflows/build-wheels-and-publish-to-pipy.yml
+++ b/.github/workflows/build-wheels-and-publish-to-pipy.yml
@@ -20,18 +20,24 @@ jobs:
         os: [ubuntu-20.04, windows-2019, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
+      
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+          
       - name: Build wheels
         env:
           # Skip 32-bit builds, MUSL libc, and pypy
           CIBW_SKIP: "*-win32 *-manylinux_i686 pp* *-musllinux*"
           CIBW_BEFORE_BUILD_LINUX: yum -y install gcc-gfortran lapack-devel blas-devel
-          CIBW_ARCHS_LINUX: "aarch64"
+          CIBW_ARCHS_LINUX: "auto aarch64"
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.11.4
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 

--- a/.github/workflows/build-wheels-and-publish-to-pipy.yml
+++ b/.github/workflows/build-wheels-and-publish-to-pipy.yml
@@ -27,6 +27,9 @@ jobs:
           # Skip 32-bit builds, MUSL libc, and pypy
           CIBW_SKIP: "*-win32 *-manylinux_i686 pp* *-musllinux*"
           CIBW_BEFORE_BUILD_LINUX: yum -y install gcc-gfortran lapack-devel blas-devel
+          CIBW_ARCHS_LINUX: "aarch64"
+          CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+          CIBW_ARCHS_WINDOWS: "ARM64"
         uses: pypa/cibuildwheel@v2.3.1
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build-wheels-and-publish-to-pipy.yml
+++ b/.github/workflows/build-wheels-and-publish-to-pipy.yml
@@ -33,8 +33,8 @@ jobs:
           # Skip 32-bit builds, MUSL libc, and pypy
           CIBW_SKIP: "*-win32 *-manylinux_i686 pp* *-musllinux*"
           CIBW_BEFORE_BUILD_LINUX: yum -y install gcc-gfortran lapack-devel blas-devel
-          CIBW_ARCHS_LINUX: "auto aarch64"
-          CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+          CIBW_ARCHS_LINUX: "aarch64"
+          CIBW_ARCHS_MACOS: "universal2 arm64"
         uses: pypa/cibuildwheel@v2.11.4
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-wheels-and-publish-to-pipy.yml
+++ b/.github/workflows/build-wheels-and-publish-to-pipy.yml
@@ -33,8 +33,8 @@ jobs:
           # Skip 32-bit builds, MUSL libc, and pypy
           CIBW_SKIP: "*-win32 *-manylinux_i686 pp* *-musllinux*"
           CIBW_BEFORE_BUILD_LINUX: yum -y install gcc-gfortran lapack-devel blas-devel
-          CIBW_ARCHS_LINUX: "aarch64"
-          CIBW_ARCHS_MACOS: "universal2 arm64"
+          CIBW_ARCHS_LINUX: "auto aarch64"
+          CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
         uses: pypa/cibuildwheel@v2.11.4
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-wheels-and-publish-to-pipy.yml
+++ b/.github/workflows/build-wheels-and-publish-to-pipy.yml
@@ -29,7 +29,6 @@ jobs:
           CIBW_BEFORE_BUILD_LINUX: yum -y install gcc-gfortran lapack-devel blas-devel
           CIBW_ARCHS_LINUX: "aarch64"
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_ARCHS_WINDOWS: "ARM64"
         uses: pypa/cibuildwheel@v2.3.1
 
       - uses: actions/upload-artifact@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(EXTERNAL_DEP_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external)
 include(DownloadExternalDeps)
 download_dep(numpyeigen
   GIT_REPOSITORY https://github.com/fwilliams/numpyeigen.git
-  GIT_TAG 9caa29b4bb49c17e6436710894a1fadeeb1eaee2
+  GIT_TAG d0eb06b4670dd939b2e11ab9a58e380180377fc6
 )
 list(APPEND CMAKE_MODULE_PATH ${EXTERNAL_DEP_DIR}/numpyeigen/cmake)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,8 @@ project(point-cloud-utils)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_BUILD_TYPE "Release")
 
-if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64")
-  option(GEOGRAM_WITH_HLBFGS "Non-linear solver (Yang Liu's HLBFGS)"             ON)
-endif()
+
+option(GEOGRAM_WITH_HLBFGS "Non-linear solver (Yang Liu's HLBFGS)"             ON)
 #option(NPE_WITH_EIGEN      "Whether to use the bundled version of Eigen"       ON)
 option(EIGEN_WITH_MKL      "Whether to build Eigen with intel MKL or not"      OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(arm64)|(ARM64)")
   endif()
 endif()
 
-set(my_BINDING_SOURCES 
+set(PCU_BINDING_SOURCES 
   ${CMAKE_CURRENT_SOURCE_DIR}/src/sample_mesh.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/sample_point_cloud.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/point_cloud_distance.cpp
@@ -154,19 +154,19 @@ set(my_BINDING_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/face_areas.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/fast_winding_numbers.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/orient_mesh_faces.cpp
-  EXTRA_MODULE_FUNCTIONS
-  hack_extra_bindings
-  hack_extra_ray_mesh_bindings
   )
 
 if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(arm64)|(ARM64)")
-    set(my_BINDING_SOURCES ${my_BINDING_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/src/lloyd.cpp)
+    set(PCU_BINDING_SOURCES ${PCU_BINDING_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/src/lloyd.cpp)
 endif()
 
 # Create the python module
 npe_add_module(_pcu_internal
   BINDING_SOURCES
-  ${my_BINDING_SOURCES}
+  ${PCU_BINDING_SOURCES}
+  EXTRA_MODULE_FUNCTIONS
+  hack_extra_bindings
+  hack_extra_ray_mesh_bindings
 )
 
 # TODO: Make common into its own library that we link statically

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(point-cloud-utils)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_BUILD_TYPE "Release")
 
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(amd64)|(AMD64)")
   option(GEOGRAM_WITH_HLBFGS "Non-linear solver (Yang Liu's HLBFGS)"             ON)
 endif()
 #option(NPE_WITH_EIGEN      "Whether to use the bundled version of Eigen"       ON)
@@ -109,7 +109,7 @@ endif()
 #target_compile_definitions(igl_embree INTERFACE -DEMBREE_STATIC_LIB)
 
 
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(amd64)|(AMD64)")
   # Build geogram
   set(THIRD_PARTY_DIR ${EXTERNAL_DEP_DIR})
   include(geogram)
@@ -161,7 +161,7 @@ npe_add_module(_pcu_internal
   hack_extra_ray_mesh_bindings
   )
 
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(amd64)|(AMD64)")
   npe_add_module(_pcu_internal
     BINDING_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/lloyd.cpp
@@ -170,7 +170,7 @@ endif()
 
 # TODO: Make common into its own library that we link statically
 target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/morton_code.cpp)
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(amd64)|(AMD64)")
   target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/geogram_utils.cpp)
 endif()
 target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/embree_intersector.cpp)
@@ -184,7 +184,7 @@ target_include_directories(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ext
 target_include_directories(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/igl/include)
 target_include_directories(_pcu_internal PRIVATE ${EMBREE_DIR}/include)
 target_link_libraries(_pcu_internal PRIVATE embree)
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(amd64)|(AMD64)")
   target_link_libraries(_pcu_internal PRIVATE geogram)
 endif()
 target_link_libraries(_pcu_internal PRIVATE manifold)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,14 @@ option(GEOGRAM_WITH_HLBFGS "Non-linear solver (Yang Liu's HLBFGS)"             O
 option(EIGEN_WITH_MKL      "Whether to build Eigen with intel MKL or not"      OFF)
 
 
-if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(arm64)|(ARM64)")
-# Turn this off if you want to build on Arm.
-option(NATIVE_SSE          "Whether to use the default optimization setup"     ON)
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "(arm64)|(ARM64)")
+  set(USING_ARM ON)
 else()
-option(NATIVE_SSE          "Whether to use the default optimization setup"     OFF)
+  set(USING_ARM OFF)
 endif()
+
+# Turn this off if you want to build on Arm.
+option(NATIVE_SSE          "Whether to use the default optimization setup"     ${USING_ARM})
 
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@ project(point-cloud-utils)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_BUILD_TYPE "Release")
 
-option(GEOGRAM_WITH_HLBFGS "Non-linear solver (Yang Liu's HLBFGS)"             ON)
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  option(GEOGRAM_WITH_HLBFGS "Non-linear solver (Yang Liu's HLBFGS)"             ON)
+endif()
 #option(NPE_WITH_EIGEN      "Whether to use the bundled version of Eigen"       ON)
 option(EIGEN_WITH_MKL      "Whether to build Eigen with intel MKL or not"      OFF)
 
@@ -107,24 +109,24 @@ endif()
 #target_compile_definitions(igl_embree INTERFACE -DEMBREE_STATIC_LIB)
 
 
-# Build geogram
-set(THIRD_PARTY_DIR ${EXTERNAL_DEP_DIR})
-include(geogram)
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  SET_TARGET_PROPERTIES(geogram PROPERTIES COMPILE_FLAGS -fopenmp LINK_FLAGS -fopenmp)
-  target_compile_options(geogram PUBLIC    -fopenmp)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # Build geogram
+  set(THIRD_PARTY_DIR ${EXTERNAL_DEP_DIR})
+  include(geogram)
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    SET_TARGET_PROPERTIES(geogram PROPERTIES COMPILE_FLAGS -fopenmp LINK_FLAGS -fopenmp)
+    target_compile_options(geogram PUBLIC    -fopenmp)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
 
-  find_package(OpenMP REQUIRED)
-  if(NOT TARGET OpenMP::OpenMP_CXX)
-    target_compile_options(OpenMP_TARGET INTERFACE ${OpenMP_CXX_FLAGS})
-    find_package(Threads REQUIRED)
-    target_link_libraries(OpenMP_TARGET INTERFACE Threads::Threads)
-    target_link_libraries(OpenMP_TARGET INTERFACE ${OpenMP_CXX_FLAGS})
+    find_package(OpenMP REQUIRED)
+    if(NOT TARGET OpenMP::OpenMP_CXX)
+      target_compile_options(OpenMP_TARGET INTERFACE ${OpenMP_CXX_FLAGS})
+      find_package(Threads REQUIRED)
+      target_link_libraries(OpenMP_TARGET INTERFACE Threads::Threads)
+      target_link_libraries(OpenMP_TARGET INTERFACE ${OpenMP_CXX_FLAGS})
+    endif()
   endif()
 endif()
-
-
 
 # Create the python module
 npe_add_module(_pcu_internal
@@ -132,7 +134,6 @@ npe_add_module(_pcu_internal
   ${CMAKE_CURRENT_SOURCE_DIR}/src/sample_mesh.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/sample_point_cloud.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/point_cloud_distance.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/lloyd.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/meshio.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/mesh_normals.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/point_cloud_normals.cpp
@@ -160,9 +161,18 @@ npe_add_module(_pcu_internal
   hack_extra_ray_mesh_bindings
   )
 
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  npe_add_module(_pcu_internal
+    BINDING_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/lloyd.cpp
+    )
+endif()
+
 # TODO: Make common into its own library that we link statically
 target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/morton_code.cpp)
-target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/geogram_utils.cpp)
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/geogram_utils.cpp)
+endif()
 target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/embree_intersector.cpp)
 target_sources(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/vcglib/wrap/ply/plylib.cpp)
 # target_sources(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/tinyply/source/tinyply.cpp)
@@ -174,7 +184,9 @@ target_include_directories(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ext
 target_include_directories(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/igl/include)
 target_include_directories(_pcu_internal PRIVATE ${EMBREE_DIR}/include)
 target_link_libraries(_pcu_internal PRIVATE embree)
-target_link_libraries(_pcu_internal PRIVATE geogram)
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  target_link_libraries(_pcu_internal PRIVATE geogram)
+endif()
 target_link_libraries(_pcu_internal PRIVATE manifold)
 # target_link_libraries(_pcu_internal PRIVATE mls_utils)
 set_target_properties(_pcu_internal PROPERTIES COMPILE_FLAGS "-fvisibility=hidden -msse3")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(point-cloud-utils)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_BUILD_TYPE "Release")
 
-if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(amd64)|(AMD64)")
+if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64")
   option(GEOGRAM_WITH_HLBFGS "Non-linear solver (Yang Liu's HLBFGS)"             ON)
 endif()
 #option(NPE_WITH_EIGEN      "Whether to use the bundled version of Eigen"       ON)
@@ -109,7 +109,7 @@ endif()
 #target_compile_definitions(igl_embree INTERFACE -DEMBREE_STATIC_LIB)
 
 
-if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(amd64)|(AMD64)")
+if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(arm64)|(ARM64)")
   # Build geogram
   set(THIRD_PARTY_DIR ${EXTERNAL_DEP_DIR})
   include(geogram)
@@ -128,9 +128,7 @@ if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(amd64)|(AMD64)")
   endif()
 endif()
 
-# Create the python module
-npe_add_module(_pcu_internal
-  BINDING_SOURCES
+set(my_BINDING_SOURCES 
   ${CMAKE_CURRENT_SOURCE_DIR}/src/sample_mesh.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/sample_point_cloud.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/point_cloud_distance.cpp
@@ -161,16 +159,19 @@ npe_add_module(_pcu_internal
   hack_extra_ray_mesh_bindings
   )
 
-if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(amd64)|(AMD64)")
-  npe_add_module(_pcu_internal
-    BINDING_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/lloyd.cpp
-    )
+if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(arm64)|(ARM64)")
+    set(my_BINDING_SOURCES ${my_BINDING_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/src/lloyd.cpp)
 endif()
+
+# Create the python module
+npe_add_module(_pcu_internal
+  BINDING_SOURCES
+  ${my_BINDING_SOURCES}
+)
 
 # TODO: Make common into its own library that we link statically
 target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/morton_code.cpp)
-if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(amd64)|(AMD64)")
+if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(arm64)|(ARM64)")
   target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/geogram_utils.cpp)
 endif()
 target_sources(_pcu_internal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/common/embree_intersector.cpp)
@@ -184,7 +185,7 @@ target_include_directories(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ext
 target_include_directories(_pcu_internal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/igl/include)
 target_include_directories(_pcu_internal PRIVATE ${EMBREE_DIR}/include)
 target_link_libraries(_pcu_internal PRIVATE embree)
-if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(amd64)|(AMD64)")
+if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(arm64)|(ARM64)")
   target_link_libraries(_pcu_internal PRIVATE geogram)
 endif()
 target_link_libraries(_pcu_internal PRIVATE manifold)

--- a/point_cloud_utils/__init__.py
+++ b/point_cloud_utils/__init__.py
@@ -1,12 +1,11 @@
 from warnings import warn
-
+import sys
 
 from ._pcu_internal import sample_mesh_poisson_disk, sample_mesh_random, \
     downsample_point_cloud_poisson_disk, estimate_mesh_vertex_normals, \
     estimate_mesh_face_normals, orient_mesh_faces, \
     k_nearest_neighbors, one_sided_hausdorff_distance, \
     morton_encode, morton_decode, morton_knn, \
-    lloyd_2d, lloyd_3d, voronoi_centroids_unit_cube, sample_mesh_lloyd, \
     deduplicate_point_cloud, deduplicate_mesh_vertices, signed_distance_to_mesh, \
     closest_points_on_mesh, connected_components, ray_mesh_intersection, laplacian_smooth_mesh, \
     make_mesh_watertight, mesh_principal_curvatures, \
@@ -14,12 +13,18 @@ from ._pcu_internal import sample_mesh_poisson_disk, sample_mesh_random, \
     sparse_voxel_grid_boundary, marching_cubes_sparse_voxel_grid, decimate_triangle_mesh, \
     remove_unreferenced_mesh_vertices, mesh_face_areas, triangle_soup_fast_winding_number
 
+if sys.platform == 'darwin':
+    from ._pcu_internal import lloyd_2d, lloyd_3d, sample_mesh_lloyd, voronoi_centroids_unit_cube
+
 from ._sinkhorn import *
 from ._mesh_io import *
 from ._octree import *
 from ._pointcloud_normals import estimate_point_cloud_normals_knn, estimate_point_cloud_normals_ball
 from ._ray_mesh_intersector import RayMeshIntersector
 from ._ray_point_cloud_intersector import ray_surfel_intersection, surfel_geometry, RaySurfelIntersector
+
+
+
 
 MORTON_MIN = -1048576
 MORTON_MAX = 1048576

--- a/point_cloud_utils/__init__.py
+++ b/point_cloud_utils/__init__.py
@@ -1,5 +1,5 @@
 from warnings import warn
-import sys
+import platform
 
 from ._pcu_internal import sample_mesh_poisson_disk, sample_mesh_random, \
     downsample_point_cloud_poisson_disk, estimate_mesh_vertex_normals, \
@@ -13,7 +13,7 @@ from ._pcu_internal import sample_mesh_poisson_disk, sample_mesh_random, \
     sparse_voxel_grid_boundary, marching_cubes_sparse_voxel_grid, decimate_triangle_mesh, \
     remove_unreferenced_mesh_vertices, mesh_face_areas, triangle_soup_fast_winding_number
 
-if sys.platform == 'darwin':
+if platform.machine == 'arm64':
     from ._pcu_internal import lloyd_2d, lloyd_3d, sample_mesh_lloyd, voronoi_centroids_unit_cube
 
 from ._sinkhorn import *

--- a/point_cloud_utils/__init__.py
+++ b/point_cloud_utils/__init__.py
@@ -1,11 +1,11 @@
 from warnings import warn
-import platform
 
 from ._pcu_internal import sample_mesh_poisson_disk, sample_mesh_random, \
     downsample_point_cloud_poisson_disk, estimate_mesh_vertex_normals, \
     estimate_mesh_face_normals, orient_mesh_faces, \
     k_nearest_neighbors, one_sided_hausdorff_distance, \
     morton_encode, morton_decode, morton_knn, \
+    lloyd_2d, lloyd_3d, voronoi_centroids_unit_cube, sample_mesh_lloyd, \
     deduplicate_point_cloud, deduplicate_mesh_vertices, signed_distance_to_mesh, \
     closest_points_on_mesh, connected_components, ray_mesh_intersection, laplacian_smooth_mesh, \
     make_mesh_watertight, mesh_principal_curvatures, \
@@ -13,18 +13,12 @@ from ._pcu_internal import sample_mesh_poisson_disk, sample_mesh_random, \
     sparse_voxel_grid_boundary, marching_cubes_sparse_voxel_grid, decimate_triangle_mesh, \
     remove_unreferenced_mesh_vertices, mesh_face_areas, triangle_soup_fast_winding_number
 
-if platform.machine() != 'arm64':
-    from ._pcu_internal import lloyd_2d, lloyd_3d, sample_mesh_lloyd, voronoi_centroids_unit_cube
-
 from ._sinkhorn import *
 from ._mesh_io import *
 from ._octree import *
 from ._pointcloud_normals import estimate_point_cloud_normals_knn, estimate_point_cloud_normals_ball
 from ._ray_mesh_intersector import RayMeshIntersector
 from ._ray_point_cloud_intersector import ray_surfel_intersection, surfel_geometry, RaySurfelIntersector
-
-
-
 
 MORTON_MIN = -1048576
 MORTON_MAX = 1048576

--- a/point_cloud_utils/__init__.py
+++ b/point_cloud_utils/__init__.py
@@ -13,7 +13,7 @@ from ._pcu_internal import sample_mesh_poisson_disk, sample_mesh_random, \
     sparse_voxel_grid_boundary, marching_cubes_sparse_voxel_grid, decimate_triangle_mesh, \
     remove_unreferenced_mesh_vertices, mesh_face_areas, triangle_soup_fast_winding_number
 
-if platform.machine == 'arm64':
+if platform.machine != 'arm64':
     from ._pcu_internal import lloyd_2d, lloyd_3d, sample_mesh_lloyd, voronoi_centroids_unit_cube
 
 from ._sinkhorn import *

--- a/point_cloud_utils/__init__.py
+++ b/point_cloud_utils/__init__.py
@@ -13,7 +13,7 @@ from ._pcu_internal import sample_mesh_poisson_disk, sample_mesh_random, \
     sparse_voxel_grid_boundary, marching_cubes_sparse_voxel_grid, decimate_triangle_mesh, \
     remove_unreferenced_mesh_vertices, mesh_face_areas, triangle_soup_fast_winding_number
 
-if platform.machine != 'arm64':
+if platform.machine() != 'arm64':
     from ._pcu_internal import lloyd_2d, lloyd_3d, sample_mesh_lloyd, voronoi_centroids_unit_cube
 
 from ._sinkhorn import *

--- a/point_cloud_utils/__init__.py
+++ b/point_cloud_utils/__init__.py
@@ -1,5 +1,6 @@
 from warnings import warn
 
+
 from ._pcu_internal import sample_mesh_poisson_disk, sample_mesh_random, \
     downsample_point_cloud_poisson_disk, estimate_mesh_vertex_normals, \
     estimate_mesh_face_normals, orient_mesh_faces, \


### PR DESCRIPTION
This PR solves compilation errors with macOS M1/M2 (Issue #50 ). The errors are due to compatibility issues between the `geogram` library and the M1 architecture.