### PR TITLE
Fix downsampling with attributes

### DIFF
--- a/src/sample_point_cloud.cpp
+++ b/src/sample_point_cloud.cpp
@@ -38,6 +38,9 @@ struct AccumulatedPoint {
     void AddPoint(const PointT& point, const AttribVecT& attrib) {
         point_ += point;
         if (attrib.cols() > 0) {
+            if (attrib_.cols() == 0) {
+                attrib_.resize(1, attrib.cols());
+            }
             attrib_ += attrib;
         }
         num_of_points_ += 1;

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -106,6 +106,7 @@ class TestDenseBindings(unittest.TestCase):
         self.assertEqual(nms.shape, pts.shape)
         self.assertGreater(pts.shape[0], 0)
         self.assertEqual(pts.shape[1], 3)
+        self.assertGreater(abs(nms[0, 0]), 1e-7)
 
         # With RBG colors
         c = np.random.rand(v.shape[0], 3)


### PR DESCRIPTION
Using `downsample_point_cloud_on_voxel_grid` with any attributes would output arrays containing zeroes for the attributes.

I'm not sure the way I fixed it is the best way to do it, but at least you're aware of the issue :slightly_smiling_face: 