### PR TITLE
Include the official aarch64 in the arm on/off switch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ option(GEOGRAM_WITH_HLBFGS "Non-linear solver (Yang Liu's HLBFGS)"             O
 # option(NPE_WITH_EIGEN      "Whether to use the bundled version of Eigen"       ON)
 option(EIGEN_WITH_MKL      "Whether to build Eigen with intel MKL or not"      OFF)
 
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "(arm64)|(ARM64)")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "(arm64)|(ARM64)|(aarch64)|(AARCH64)")
   set(NOT_USING_ARM OFF)
 else()
   set(NOT_USING_ARM ON)


### PR DESCRIPTION
On certain platform the `${CMAKE_SYSTEM_PROCESSOR}` returns `aarch64` instead of `arm64` which causes the `NOT_USING_ARM` to be to ON and thus fail to build the project.