### PR TITLE
Increase verbosity and disambiguate artifact names

### DIFF
--- a/.github/workflows/build-wheels-and-publish-to-pipy.yml
+++ b/.github/workflows/build-wheels-and-publish-to-pipy.yml
@@ -35,11 +35,13 @@ jobs:
           CIBW_BEFORE_BUILD_LINUX: yum -y install gcc-gfortran lapack-devel blas-devel
           CIBW_ARCHS_LINUX: "auto"
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: "" # delocate-listdeps --all {wheel} && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          CIBW_BUILD_VERBOSITY: 1
           # CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
         uses: pypa/cibuildwheel@v2.23.2
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
+          overwrite: true
 
   build_sdist:
     name: Build source distribution

--- a/.github/workflows/build-wheels-and-publish-to-pipy.yml
+++ b/.github/workflows/build-wheels-and-publish-to-pipy.yml
@@ -40,8 +40,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.23.2
       - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-${{ matrix.os }}-${{ matrix.cibw_archs }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
-          overwrite: true
 
   build_sdist:
     name: Build source distribution
@@ -54,6 +54,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: cibw-sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -66,8 +67,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4.1.7
         with:
-          name: artifact
+          name: cibw-*
           path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@v1.4.2
         with:


### PR DESCRIPTION
upload-artifact@v4 doesn't allow the wheel and sdist artifacts to be the same and implicitly combined. They need to be disambiguated and merged upon download prior to PyPI upload.

See https://github.com/pypa/cibuildwheel/issues/1699 for reference.