### PR TITLE
Fix color types casting

### DIFF
--- a/point_cloud_utils/_mesh_io.py
+++ b/point_cloud_utils/_mesh_io.py
@@ -288,11 +288,21 @@ class TriangleMesh:
             if wcolors.max() > 1.0 or wcolors.min() < 0.0:
                 raise ValueError("Invalid values for wedge colors, must be between 0 and 1 (inclusive)")
 
+        # Meshlab expects colors to be uint8 for PLY files
+        if filename.endswith(".ply"):
+            vcolors = (vcolors * 255.0).astype(np.uint8)
+            fcolors = (fcolors * 255.0).astype(np.uint8)
+            wcolors = (wcolors * 255.0).astype(np.uint8)
+        else:
+            vcolors = vcolors.astype(dtype)
+            fcolors = fcolors.astype(dtype)
+            wcolors = wcolors.astype(dtype)
+
         save_mesh_internal(filename,
                            np.ascontiguousarray(self.vertex_data.positions.astype(dtype)),
                            np.ascontiguousarray(self.vertex_data.normals.astype(dtype)),
                            np.ascontiguousarray(self.vertex_data.texcoords.astype(dtype)),
-                           np.ascontiguousarray((vcolors * 255.0).astype(np.uint8)),
+                           np.ascontiguousarray(vcolors),
                            np.ascontiguousarray(self.vertex_data.quality.astype(dtype)),
                            np.ascontiguousarray(self.vertex_data.radius.astype(dtype)),
                            np.ascontiguousarray(self.vertex_data.tex_ids.astype(np.int32)),
@@ -300,11 +310,11 @@ class TriangleMesh:
 
                            np.ascontiguousarray(self.face_data.vertex_ids.astype(np.int32)),
                            np.ascontiguousarray(self.face_data.normals.astype(dtype)),
-                           np.ascontiguousarray((fcolors * 255.0).astype(np.uint8)),
+                           np.ascontiguousarray(fcolors),
                            np.ascontiguousarray(self.face_data.quality.astype(dtype)),
                            np.ascontiguousarray(self.face_data.flags.astype(np.int32)),
 
-                           np.ascontiguousarray((wcolors * 255.0).astype(np.uint8)),
+                           np.ascontiguousarray(wcolors),
                            np.ascontiguousarray(self.face_data.wedge_normals.astype(dtype)),
                            np.ascontiguousarray(self.face_data.wedge_texcoords.astype(dtype)),
                            np.ascontiguousarray(self.face_data.wedge_tex_ids.astype(np.int32)),

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ def main():
 
     setuptools.setup(
         name="point-cloud-utils",
-        version="0.34.0",
+        version="0.35.0",
         author="Francis Williams",
         author_email="francis@fwilliams.info",
         description="A Python library for common tasks on 3D point clouds and meshes",


### PR DESCRIPTION
Fixes #103. 

This maintains the possibilty to store color in `.ply` files as uint8 (so that they can be loaded in Meshlab as proposed in https://github.com/fwilliams/point-cloud-utils/commit/dee37e4d2ee9a4e1fa8e6cd34fabc7cf748304f4) and stores them as floats for other file extensions to avoid the ValueError.  

Alternatively could be solved by changing the expected types in the different `save_mesh_obj`, `save_mesh_...` but would be a bit more effort :)

Screenshots of same mesh exported as `ply` and `obj` in Meshlab
![Screenshot 2025-04-17 at 5 42 15 PM (2)](https://github.com/user-attachments/assets/a9965a55-86b8-4b67-b6a2-0693339bfb8f)
![Screenshot 2025-04-17 at 5 42 10 PM (2)](https://github.com/user-attachments/assets/c303c44c-7adc-4d17-a49f-2835373fed2d)
