### PR TITLE
Fix build on modern CMake 4 / pybind11 / conda toolchains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,9 @@ set_target_properties(manifold PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(manifold PUBLIC ${MANIFOLD_SRC_DIR})
 target_include_directories(manifold PRIVATE ${EXTERNAL_DEP_DIR}/manifold/3rd)
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    target_compile_options(manifold PRIVATE "${CMAKE_CXX_FLAGS} -Wall -pthread -DWITH_OMP  -Wno-int-in-bool-context -Wsign-compare -fsanitize=address")
+    target_compile_options(manifold PRIVATE -Wall -pthread -DWITH_OMP -Wno-int-in-bool-context -Wsign-compare -fsanitize=address)
 else()
-    target_compile_options(manifold PRIVATE "${CMAKE_CXX_FLAGS} -DWITH_OMP ")
+    target_compile_options(manifold PRIVATE -DWITH_OMP)
 endif()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "scipy", "numpy", "cmake>=3.2"]
+requires = ["setuptools>=42", "wheel", "scipy", "numpy", "cmake>=3.2,<4"]
 build-backend = "setuptools.build_meta"

--- a/src/common/ply_loader.h
+++ b/src/common/ply_loader.h
@@ -74,7 +74,7 @@ pybind11::array ply_data_to_array(std::shared_ptr<tinyply::PlyData> attrib) {
     if (attrib->count == 0) {
         return pybind11::array(attrib_dtype, std::vector<size_t>({0, 0}));
     }
-    size_t bytes_per_scalar = attrib_dtype.elsize();
+    size_t bytes_per_scalar = attrib_dtype.itemsize();
     if (bytes_per_scalar <= 0) {
         throw std::runtime_error("Internal PLY loading error. Type has no defined byte size.");
     }


### PR DESCRIPTION
Building `point-cloud-utils` (v0.35.0) on a current toolchain — Linux
x86_64, Python 3.14, a conda GCC 13.2 toolchain, CMake 4, torch 2.12 /
numpy 2 — hits three independent build failures. Each commit fixes one.

**1. `manifold` `target_compile_options` passes `CMAKE_CXX_FLAGS` as one arg**

```cmake
target_compile_options(manifold PRIVATE "${CMAKE_CXX_FLAGS} -DWITH_OMP ")
```

`target_compile_options` treats each argument as a single option, so the
quoted string is handed to the compiler as one bogus argument. When
`CMAKE_CXX_FLAGS` is non-empty (e.g. conda exports
`CXXFLAGS="-fvisibility-inlines-hidden -march=nocona ..."`) the build fails:

```
g++: error: unrecognized command-line option
     '-fvisibility-inlines-hidden -fmessage-length=0 ... -DWITH_OMP '
```

`CMAKE_CXX_FLAGS` is already applied to every target by CMake, so
re-injecting it here is redundant as well as broken. Pass the
manifold-specific flags unquoted as separate options.

**2. pybind11 `dtype::elsize()` removed — use `itemsize()`**

`pybind11::dtype::elsize()` is not present in current pybind11 (required
for Python 3.14 / NumPy 2 support). `src/common/ply_loader.h` fails with:

```
error: 'class pybind11::dtype' has no member named 'elsize'; did you mean 'itemsize'?
```

`itemsize()` is the equivalent accessor.

**3. Pin build-time CMake < 4**

The `numpyeigen` dependency fetched at configure time declares
`cmake_minimum_required` below 3.5, support for which CMake 4 removed
(hard error). Constraining the build-system requirement lets an isolated
build resolve a 3.x CMake. (Happy to drop this commit if you'd rather fix
the policy version on the numpyeigen side instead.)

With all three, the wheel builds cleanly and `pcu.chamfer_distance` etc.
work on Python 3.14.
